### PR TITLE
Normalize table results from API

### DIFF
--- a/src/components/ResultsDisplay.jsx
+++ b/src/components/ResultsDisplay.jsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.j
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.jsx';
 import { Button } from '@/components/ui/button.jsx';
 import { Badge } from '@/components/ui/badge.jsx';
+import { normalizeTables } from '@/lib/utils.js';
 import { 
   FileText, 
   Table as TableIcon, 
@@ -266,6 +267,8 @@ const ChunksViewer = ({ chunks }) => {
 const ResultsDisplay = ({ results }) => {
   if (!results) return null;
 
+  const tables = normalizeTables(results.tables);
+
   const downloadResults = () => {
     const dataStr = JSON.stringify(results, null, 2);
     const dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr);
@@ -307,11 +310,11 @@ const ResultsDisplay = ({ results }) => {
           </TabsList>
           
           <TabsContent value="content" className="mt-6">
-            <MarkdownRenderer content={results.markdown} tables={results.tables} />
+            <MarkdownRenderer content={results.markdown} tables={tables} />
           </TabsContent>
           
           <TabsContent value="tables" className="mt-6">
-            <TableViewer tables={results.tables} />
+            <TableViewer tables={tables} />
           </TabsContent>
           
           <TabsContent value="chunks" className="mt-6">

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+// Normalize table data to always return an array of tables
+// Accepts arrays or objects with table values
+export function normalizeTables(tables) {
+  if (!tables) return [];
+  if (Array.isArray(tables)) return tables;
+  if (typeof tables === 'object') return Object.values(tables);
+  return [];
+}


### PR DESCRIPTION
## Summary
- normalize table data (handles object or array)
- use normalized tables when rendering results

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6855a22b9118832289c9860c42dbdf55